### PR TITLE
Added tetrahedron to face transform

### DIFF
--- a/code/datasets/transforms.py
+++ b/code/datasets/transforms.py
@@ -214,16 +214,17 @@ class TransformType(Enum):
 
 
 class TriangulationToFaceTransform:
-    '''
-    Transforms tetrahedra to faces. 
-    Expects a triangulation of shape [4,N] and 
+    """
+    Transforms tetrahedra to faces.
+    Expects a triangulation of shape [4,N] and
     returns the faces of shape [3,M].
 
-    NOTE: It will contain duplicate triangles with different ordering. 
-    Hence the result is not a "minimal" triangulation. When subsequently 
-    converting the triangles to edges, this will not pose a problem as 
-    the FaceToEdge transform by default creates undirected edges. 
-    '''
+    NOTE: It will contain duplicate triangles with different ordering.
+    Hence the result is not a "minimal" triangulation. When subsequently
+    converting the triangles to edges, this will not pose a problem as
+    the FaceToEdge transform by default creates undirected edges.
+    """
+
     def __init__(self, remove_triangulation: bool = True) -> None:
         self.remove_triangulation = remove_triangulation
 
@@ -233,8 +234,8 @@ class TriangulationToFaceTransform:
             assert data.triangulation is not None
             face = torch.cat([data.triangulation[i] for i in idx], dim=1)
 
-            # Remove duplicate triangles in 
-            data.face = torch.unique(face,dim=1)
+            # Remove duplicate triangles in
+            data.face = torch.unique(face, dim=1)
 
             if self.remove_triangulation:
                 data.triangulation = None


### PR DESCRIPTION
I have added the tetrahedron to triangle transform. 
The question is how we are going to handle triangles in different orders.
- For face to edges, pytorch geometric adds all permutations to the edge list, making it unordered. So a face [0,1,2] results in 6 edges. Namely [[0,1],[1,0],[0,2],[2,0],[1,2],[2,1]]. 
- If we exclusively convert the faces to edges afterwards it will not be a problem, but if we want to also use the triangles we need to find the unique faces. 

